### PR TITLE
feat(sai): add sai api headers version to get component versions

### DIFF
--- a/platform/mellanox/component-versions/create_component_versions.sh
+++ b/platform/mellanox/component-versions/create_component_versions.sh
@@ -18,6 +18,21 @@
 echo "SDK $1" > temp_versions_file
 echo $2 | sed -r 's/([0-9]*)\.([0-9]*)\.([0-9]*)/FW \2\.\3/g' >> temp_versions_file
 echo "SAI $3" >> temp_versions_file
+
+SAI_API_VERSION_PATH="src/sonic-sairedis/SAI/inc/saiversion.h"
+if [ -f "$SAI_API_VERSION_PATH" ]; then
+    SAI_MAJOR=$(grep "SAI_MAJOR" "$SAI_API_VERSION_PATH" | grep -o "[0-9]*")
+    SAI_MINOR=$(grep "SAI_MINOR" "$SAI_API_VERSION_PATH" | grep -o "[0-9]*")
+    SAI_REVISION=$(grep "SAI_REVISION" "$SAI_API_VERSION_PATH" | grep -o "[0-9]*")
+    if [ -n "$SAI_MAJOR" ] && [ -n "$SAI_MINOR" ] && [ -n "$SAI_REVISION" ]; then
+        echo "SAI_API_HEADERS $SAI_MAJOR.$SAI_MINOR.$SAI_REVISION" >> temp_versions_file
+    else
+        echo "SAI_API_HEADERS N/A" >> temp_versions_file
+    fi
+else
+    echo "SAI_API_HEADERS N/A" >> temp_versions_file
+fi
+
 echo "HW_MANAGEMENT $4" >> temp_versions_file
 echo "MFT $5-$6" >> temp_versions_file
 echo "KERNEL $7" >> temp_versions_file

--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -40,6 +40,7 @@ COMMANDS_FOR_ACTUAL = {
     "HW_MANAGEMENT": [["dpkg", "-l"], ["grep", "hw"], ".*1\\.mlnx\\.([0-9.]*)"],
     "SDK": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep sdk'], ".*1\\.mlnx\\.([0-9.]*)"],
     "SAI": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
+    "SAI_API_HEADERS": [["docker", "exec", "-it", "syncd", "bash", "-c", 'grep -E "SAI_MAJOR|SAI_MINOR|SAI_REVISION" /usr/include/sai/saiversion.h'], "SAI_MAJOR\\s+(\\d+).*SAI_MINOR\\s+(\\d+).*SAI_REVISION\\s+(\\d+)"],
     "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "([0-9][0-9.-]*)-.*"]
 }
@@ -48,6 +49,7 @@ UNAVAILABLE_COMPILED_VERSIONS = {
     "SDK": "N/A",
     "FW": "N/A",
     "SAI": "N/A",
+    "SAI_API_HEADERS": "N/A",
     "HW_MANAGEMENT": "N/A",
     "MFT": "N/A",
     "KERNEL": "N/A",

--- a/platform/mellanox/get_component_versions/test_sai_api_version.py
+++ b/platform/mellanox/get_component_versions/test_sai_api_version.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import re
+import unittest
+
+
+def _extract_version_from_content(content):
+    """
+    Extract SAI API version from header content.
+    Returns the version string in format X.Y.Z or N/A if not available.
+    """
+    try:
+        major_match = re.search(r'#define SAI_MAJOR\s+(\d+)', content)
+        minor_match = re.search(r'#define SAI_MINOR\s+(\d+)', content)
+        revision_match = re.search(r'#define SAI_REVISION\s+(\d+)', content)
+        
+        if major_match and minor_match and revision_match:
+            major = major_match.group(1)
+            minor = minor_match.group(1)
+            revision = revision_match.group(1)
+            return f"{major}.{minor}.{revision}"
+        else:
+            return "N/A"
+            
+    except Exception:
+        return "N/A"
+
+
+class TestSAIVersionExtraction(unittest.TestCase):
+    
+    def test_valid_sai_api_version(self):
+        """Test extraction of valid SAI version"""
+        content = """
+        #define SAI_MAJOR 1
+        #define SAI_MINOR 16
+        #define SAI_REVISION 1
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "1.16.1")
+    
+    def test_missing_major(self):
+        """Test handling of missing SAI_MAJOR"""
+        content = """
+        #define SAI_MINOR 16
+        #define SAI_REVISION 1
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "N/A")
+    
+    def test_missing_minor(self):
+        """Test handling of missing SAI_MINOR"""
+        content = """
+        #define SAI_MAJOR 1
+        #define SAI_REVISION 1
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "N/A")
+    
+    def test_missing_revision(self):
+        """Test handling of missing SAI_REVISION"""
+        content = """
+        #define SAI_MAJOR 1
+        #define SAI_MINOR 16
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "N/A")
+    
+    def test_different_version_numbers(self):
+        """Test extraction of different version numbers"""
+        content = """
+        #define SAI_MAJOR 2
+        #define SAI_MINOR 5
+        #define SAI_REVISION 10
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "2.5.10")
+    
+    def test_empty_content(self):
+        """Test handling of empty content"""
+        content = ""
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "N/A")
+    
+    def test_malformed_content(self):
+        """Test handling of malformed content"""
+        content = """
+        #define SAI_MAJOR abc
+        #define SAI_MINOR def
+        #define SAI_REVISION ghi
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "N/A")
+    
+    def test_extract_version_from_content(self):
+        """Test the helper function for extracting version from content"""
+        content = """
+        #define SAI_MAJOR 1
+        #define SAI_MINOR 16
+        #define SAI_REVISION 1
+        """
+        version = _extract_version_from_content(content)
+        self.assertEqual(version, "1.16.1")
+        
+        content2 = """
+        #define SAI_MAJOR 2
+        #define SAI_MINOR 5
+        #define SAI_REVISION 10
+        """
+        version2 = _extract_version_from_content(content2)
+        self.assertEqual(version2, "2.5.10")


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

